### PR TITLE
Fix/EIP 712 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.1.0
+
+- Fix: Use contract versions as part of EIP712 signatures
+- Refactor: Update version type from 'uint16' to 'string'
+
 ## 2.0.0
 
 - Set Contract License to Apache License, Version 2.0

--- a/contracts/common/IdentityHandler.sol
+++ b/contracts/common/IdentityHandler.sol
@@ -15,8 +15,9 @@ abstract contract IdentityHandler is IIdentityHandler, Context, EIP712 {
     constructor(
         address didRegistry,
         bytes32 delegateType,
-        string memory name
-    ) EIP712(name, "1") {
+        string memory name,
+        string memory version
+    ) EIP712(name, version) {
         // version is expected to be updated if new version is released
         defaultDidRegistry = didRegistry;
         defaultDelegateType = delegateType;

--- a/contracts/verification-registry/generic/VerificationRegistry.sol
+++ b/contracts/verification-registry/generic/VerificationRegistry.sol
@@ -10,9 +10,16 @@ contract VerificationRegistry is IVerificationRegistry, IdentityHandler {
     constructor(
         address didRegistry,
         bytes32 delegateType
-    ) IdentityHandler(didRegistry, delegateType, "VerificationRegistry") {}
+    )
+        IdentityHandler(
+            didRegistry,
+            delegateType,
+            "VerificationRegistry",
+            version
+        )
+    {}
 
-    uint16 public constant version = 2;
+    string public constant version = "210"; // max value MUST BE 0xffff
     mapping(bytes32 => mapping(address => Detail)) private registers;
     bytes32 private constant REVOKE_TYPEHASH =
         keccak256("Revoke(bytes32 digest,address identity)");

--- a/test/verificationRegistry/VerificationRegistryGM.test.ts
+++ b/test/verificationRegistry/VerificationRegistryGM.test.ts
@@ -15,6 +15,7 @@ const genericMessage = "some message";
 const didRegistryArtifactName = "DIDRegistryGM";
 const defaultDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
 const EIP712ContractName = "VerificationRegistry";
+const contractVersion = "210";
 describe(artifactName, function () {
   async function deployDidRegistry(
     keyRotationTime = 3600
@@ -778,7 +779,8 @@ async function getTypedDataHashForIssue(
   contractName = EIP712ContractName,
   message = "some message",
   delta = 3600 * 24 * 365,
-  chainId = network.config.chainId
+  chainId = network.config.chainId,
+  version = contractVersion
 ): Promise<{ typeDataHash: string; digest: string; exp: number }> {
   const ISSUE_TYPEHASH = keccak256(
     toUtf8Bytes("Issue(bytes32 digest,uint256 exp,address identity)")
@@ -803,7 +805,7 @@ async function getTypedDataHashForIssue(
     )
   );
   const _hashedName = keccak256(toUtf8Bytes(contractName));
-  const _hashedVersion = keccak256(toUtf8Bytes("1"));
+  const _hashedVersion = keccak256(toUtf8Bytes(version));
 
   const contractAddress = verificationRegistryAddress;
   const eds = defaultAbiCoder.encode(
@@ -853,7 +855,7 @@ async function getTypedDataHashForRevocation(
 
 async function getDomainSeparator(
   contractName: string,
-  version = "1",
+  version = contractVersion,
   chainId = network.config.chainId
 ): Promise<string> {
   // 1. EIP712


### PR DESCRIPTION
Fix: Use contract versions as part of EIP712 signatures
Refactor: Update version type from 'uint16' to 'string'