### PR TITLE
Cv 2748 revocation onhold signed methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.1.0
+
+- Fix: Emit event when an entity removes its custom didRegistry
+- Feat: Add methods to set onHold by default delegate and default delegate with custom type using meta transactions with EIP-712
+- Feat: Add methods to add custom DIDRegistry and custom delegate types using meta transactions with EIP-712
+
 ### 0.0.9
 
 - Fix: Use contract versions as part of EIP712 signatures

--- a/contracts/common/IdentityHandler.sol
+++ b/contracts/common/IdentityHandler.sol
@@ -11,6 +11,18 @@ abstract contract IdentityHandler is IIdentityHandler, Context, EIP712 {
     mapping(address => address) public didRegistries;
     // identity => delegateType => bool
     mapping(address => mapping(bytes32 => bool)) public didDelegateTypes;
+    mapping(address => mapping(bytes32 => bool)) public nonces;
+    bytes32 private constant ADD_DID_REGISTRY_TYPEHASH =
+        keccak256("AddDidRegistry(address didRegistryAddress,bytes32 nonce)");
+
+    bytes32 private constant REMOVE_DID_REGISTRY_TYPEHASH =
+        keccak256("RemoveDidRegistry(bytes32 nonce)");
+
+    bytes32 private constant ADD_DELETEGATE_TYPE_TYPEHASH =
+        keccak256("AddDelegateType(bytes32 delegateType,bytes32 nonce)");
+
+    bytes32 private constant REMOVE_DELETEGATE_TYPE_TYPEHASH =
+        keccak256("RemoveDelegateType(bytes32 delegateType,bytes32 nonce)");
 
     constructor(
         address didRegistry,
@@ -67,20 +79,71 @@ abstract contract IdentityHandler is IIdentityHandler, Context, EIP712 {
     }
 
     function addDidRegistry(address didRegistryAddress) external {
+        _addDidRegistry(didRegistryAddress, _msgSender());
+    }
+
+    function _addDidRegistry(
+        address didRegistryAddress,
+        address actor
+    ) internal {
         // @todo add extcodesize and function selector verification
         require(
             didRegistryAddress != address(0) &&
-                didRegistries[_msgSender()] == address(0),
+                didRegistries[actor] == address(0),
             "IP"
         );
-        didRegistries[_msgSender()] = didRegistryAddress;
-        emit DidRegistryChange(_msgSender(), didRegistryAddress, true);
+        didRegistries[actor] = didRegistryAddress;
+        emit DidRegistryChange(actor, didRegistryAddress, true);
+    }
+
+    function addDidRegistrySigned(
+        address didRegistryAddress,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
+        bytes memory message = abi.encode(
+            ADD_DID_REGISTRY_TYPEHASH,
+            didRegistryAddress,
+            nonce
+        );
+        bytes32 structHash = keccak256(message);
+        bytes32 completeHash = _hashTypedDataV4(structHash);
+        address actor = ecrecover(completeHash, sigV, sigR, sigS);
+        _validateAndSetNonce(actor, nonce);
+        _addDidRegistry(didRegistryAddress, actor);
+    }
+
+    function _validateAndSetNonce(address actor, bytes32 nonce) internal {
+        require(!nonces[actor][nonce], "NAR");
+        nonces[actor][nonce] = true;
     }
 
     function removeDidRegistry() external {
+        _removeDidRegistry(_msgSender());
+    }
+
+    function _removeDidRegistry(address actor) internal {
         // @todo add extcodesize and function selector verification
-        require(didRegistries[_msgSender()] != address(0), "CDNS");
-        didRegistries[_msgSender()] = address(0);
+        address didRegistryAddress = didRegistries[actor];
+        require(didRegistries[actor] != address(0), "CDNS");
+        didRegistries[actor] = address(0);
+        emit DidRegistryChange(actor, didRegistryAddress, false);
+    }
+
+    function removeDidRegistrySigned(
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
+        bytes memory message = abi.encode(REMOVE_DID_REGISTRY_TYPEHASH, nonce);
+        bytes32 structHash = keccak256(message);
+        bytes32 completeHash = _hashTypedDataV4(structHash);
+        address actor = ecrecover(completeHash, sigV, sigR, sigS);
+        _validateAndSetNonce(actor, nonce);
+        _removeDidRegistry(actor);
     }
 
     function _validateDelegate(
@@ -115,17 +178,13 @@ abstract contract IdentityHandler is IIdentityHandler, Context, EIP712 {
 
     function _validateDelegateWithCustomType(
         bytes32 delegateType,
-        address identity
+        address identity,
+        address delegate
     ) internal view {
         // resolve didRegistry to call
         address registryAddress = getDidRegistry(identity);
         require(isValidDelegateType(identity, delegateType), "DTNS");
-        _validateDelegate(
-            registryAddress,
-            identity,
-            delegateType,
-            _msgSender()
-        );
+        _validateDelegate(registryAddress, identity, delegateType, delegate);
     }
 
     function isValidDelegateType(
@@ -136,13 +195,57 @@ abstract contract IdentityHandler is IIdentityHandler, Context, EIP712 {
     }
 
     function addDelegateType(bytes32 delegateType) external {
-        address by = _msgSender();
+        _addDelegateType(delegateType, _msgSender());
+    }
+
+    function _addDelegateType(bytes32 delegateType, address by) internal {
         _delegateTypeChange(delegateType, by, true);
     }
 
+    function addDelegateTypeSigned(
+        bytes32 delegateType,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
+        bytes memory message = abi.encode(
+            ADD_DELETEGATE_TYPE_TYPEHASH,
+            delegateType,
+            nonce
+        );
+        bytes32 structHash = keccak256(message);
+        bytes32 completeHash = _hashTypedDataV4(structHash);
+        address actor = ecrecover(completeHash, sigV, sigR, sigS);
+        _validateAndSetNonce(actor, nonce);
+        _addDelegateType(delegateType, actor);
+    }
+
     function removeDelegateType(bytes32 delegateType) external {
-        address by = _msgSender();
+        _removeDelegateType(delegateType, _msgSender());
+    }
+
+    function _removeDelegateType(bytes32 delegateType, address by) internal {
         _delegateTypeChange(delegateType, by, false);
+    }
+
+    function removeDelegateTypeSigned(
+        bytes32 delegateType,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
+        bytes memory message = abi.encode(
+            REMOVE_DELETEGATE_TYPE_TYPEHASH,
+            delegateType,
+            nonce
+        );
+        bytes32 structHash = keccak256(message);
+        bytes32 completeHash = _hashTypedDataV4(structHash);
+        address actor = ecrecover(completeHash, sigV, sigR, sigS);
+        _validateAndSetNonce(actor, nonce);
+        _removeDelegateType(delegateType, actor);
     }
 
     function _delegateTypeChange(

--- a/contracts/verification-registry/generic/VerificationRegistry.sol
+++ b/contracts/verification-registry/generic/VerificationRegistry.sol
@@ -19,12 +19,21 @@ contract VerificationRegistry is IVerificationRegistry, IdentityHandler {
         )
     {}
 
-    string public constant version = "009"; // max value MUST BE 0xffff
+    string public constant version = "010"; // max value MUST BE 0xffff
     mapping(bytes32 => mapping(address => Detail)) private registers;
     bytes32 private constant REVOKE_TYPEHASH =
         keccak256("Revoke(bytes32 digest,address identity)");
     bytes32 private constant ISSUE_TYPEHASH =
         keccak256("Issue(bytes32 digest,uint256 exp,address identity)");
+    bytes32 private constant ONHOLD_TYPEHASH =
+        keccak256(
+            "OnHold(bytes32 digest,address identity,bool onHoldStatus,bytes32 nonce)"
+        );
+
+    bytes32 private constant ONHOLD_WITH_CUSTOM_DELEGATE_TYPE_TYPEHASH =
+        keccak256(
+            "OnHoldByDelegateWithCustomType(bytes32 digest,address identity,bool onHoldStatus,bytes32 nonce,bytes32 delegateType)"
+        );
 
     function issue(bytes32 digest, uint256 exp, address identity) external {
         _validateController(getDidRegistry(identity), _msgSender(), identity);
@@ -89,6 +98,37 @@ contract VerificationRegistry is IVerificationRegistry, IdentityHandler {
         emit NewOnHoldChange(digest, by, onHoldStatus, currentTime);
     }
 
+    function onHoldChangeSigned(
+        bytes32 digest,
+        address identity,
+        bool onHoldStatus,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
+        bytes memory message = abi.encode(
+            ONHOLD_TYPEHASH,
+            digest,
+            identity,
+            onHoldStatus,
+            nonce
+        );
+        bytes32 structHash = keccak256(message);
+        bytes32 completeHash = _hashTypedDataV4(structHash);
+        address didRegistry = getDidRegistry(identity);
+        checkControllerSignature(
+            didRegistry,
+            identity,
+            sigV,
+            sigR,
+            sigS,
+            completeHash
+        );
+        _onHoldChange(identity, digest, onHoldStatus);
+        _validateAndSetNonce(identity, nonce);
+    }
+
     function _revoke(address by, bytes32 digest) private {
         uint256 exp = block.timestamp;
         Detail storage detail = registers[digest][by];
@@ -139,7 +179,7 @@ contract VerificationRegistry is IVerificationRegistry, IdentityHandler {
         bytes32 digest,
         uint256 exp
     ) external {
-        _validateDelegateWithCustomType(delegateType, identity);
+        _validateDelegateWithCustomType(delegateType, identity, _msgSender());
         _issue(identity, digest, exp);
     }
 
@@ -301,7 +341,7 @@ contract VerificationRegistry is IVerificationRegistry, IdentityHandler {
         address identity,
         bytes32 digest
     ) external {
-        _validateDelegateWithCustomType(delegateType, identity);
+        _validateDelegateWithCustomType(delegateType, identity, _msgSender());
         _revoke(identity, digest);
     }
 
@@ -367,13 +407,144 @@ contract VerificationRegistry is IVerificationRegistry, IdentityHandler {
         _onHoldChange(identity, digest, onHoldStatus);
     }
 
+    function onHoldByDelegateSigned(
+        bytes32 digest,
+        address identity,
+        bool onHoldStatus,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
+        bytes32 delegateType = _getDefaultDelegateType();
+        _onHoldByDelegateSigned(
+            delegateType,
+            identity,
+            digest,
+            onHoldStatus,
+            nonce,
+            sigV,
+            sigR,
+            sigS
+        );
+    }
+
+    function _onHoldByDelegateSigned(
+        bytes32 delegateType,
+        address identity,
+        bytes32 digest,
+        bool onHoldStatus,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) private {
+        bytes memory message = abi.encode(
+            ONHOLD_TYPEHASH,
+            digest,
+            identity,
+            onHoldStatus,
+            nonce
+        );
+        __onHoldByDelegateSigned(
+            delegateType,
+            identity,
+            digest,
+            onHoldStatus,
+            message,
+            sigV,
+            sigR,
+            sigS
+        );
+    }
+
+    function _onHoldByDelegateWithCustomTypeSigned(
+        bytes32 delegateType,
+        address identity,
+        bytes32 digest,
+        bool onHoldStatus,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) private {
+        bytes memory message = abi.encode(
+            ONHOLD_WITH_CUSTOM_DELEGATE_TYPE_TYPEHASH,
+            digest,
+            identity,
+            onHoldStatus,
+            nonce,
+            delegateType
+        );
+        __onHoldByDelegateSigned(
+            delegateType,
+            identity,
+            digest,
+            onHoldStatus,
+            message,
+            sigV,
+            sigR,
+            sigS
+        );
+    }
+
+    function __onHoldByDelegateSigned(
+        bytes32 delegateType,
+        address identity,
+        bytes32 digest,
+        bool onHoldStatus,
+        bytes memory message,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) private {
+        bytes32 structHash = keccak256(message);
+        bytes32 completeHash = _hashTypedDataV4(structHash);
+
+        bytes32 dt = delegateType; // avoid stack too deep
+
+        address didRegistry = getDidRegistry(identity);
+        checkDelegateSignature(
+            didRegistry,
+            identity,
+            sigV,
+            sigR,
+            sigS,
+            completeHash,
+            dt
+        );
+        _onHoldChange(identity, digest, onHoldStatus);
+    }
+
     function onHoldByDelegateWithCustomType(
         bytes32 delegateType,
         address identity,
         bytes32 digest,
         bool onHoldStatus
     ) external {
-        _validateDelegateWithCustomType(delegateType, identity);
+        _validateDelegateWithCustomType(delegateType, identity, _msgSender());
         _onHoldChange(identity, digest, onHoldStatus);
+    }
+
+    function onHoldByDelegateWithCustomTypeSigned(
+        bytes32 delegateType,
+        address identity,
+        bytes32 digest,
+        bool onHoldStatus,
+        bytes32 nonce,
+        uint8 sigV,
+        bytes32 sigR,
+        bytes32 sigS
+    ) external {
+        _onHoldByDelegateWithCustomTypeSigned(
+            delegateType,
+            identity,
+            digest,
+            onHoldStatus,
+            nonce,
+            sigV,
+            sigR,
+            sigS
+        );
     }
 }

--- a/docs/tech/errorMessages.md
+++ b/docs/tech/errorMessages.md
@@ -16,3 +16,4 @@
 - SCF -> Static Call Failed
 - IOHCS -> Invalid OnHold Change Status
 - RNIBE -> Registry not issued by entity
+- NAR -> Nonce already used

--- a/docs/tech/testing.md
+++ b/docs/tech/testing.md
@@ -5,5 +5,6 @@
 Tests are made against Lacchain Open Pro Testnet because of the Gas Model needed to simulate transactions.
 
 ```sh
- yarn hardhat test test/verificationRegistry/VerificationRegistryGM.test.ts  --network lacchain
+ yarn hardhat test test/verificationRegistry/VerificationRegistry.test.ts # test on development network
+ yarn hardhat test test/verificationRegistry/VerificationRegistryGM.test.ts --network lacchain # run test on a gas model network
 ```

--- a/docs/tech/testing.md
+++ b/docs/tech/testing.md
@@ -6,5 +6,5 @@ Tests are made against Lacchain Open Pro Testnet because of the Gas Model needed
 
 ```sh
  yarn hardhat test test/verificationRegistry/VerificationRegistry.test.ts # test on development network
- yarn hardhat test test/verificationRegistry/VerificationRegistryGM.test.ts --network lacchain # run test on a gas model network
+ yarn hardhat test test/verificationRegistry/VerificationRegistry.test.ts --network lacchain # run test on a gas model network
 ```

--- a/scripts/deployVerificationRegistryGM.ts
+++ b/scripts/deployVerificationRegistryGM.ts
@@ -4,8 +4,8 @@ import { formatBytes32String } from "ethers/lib/utils";
 async function main() {
   const accounts = lacchain.getSigners();
   const artifactName = "VerificationRegistryGM";
-  const defaultDidRegistry = "0x43dE0954a2c83A415d82b9F31705B969b5856003"; // UPDATE this!
-  const defaultDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+  const defaultDidRegistry = "0xd2d7bF1A9a774f09cbA9541c5326B22f83f734Df"; // UPDATE this!
+  const defaultDelegateType = formatBytes32String("veriKey"); // bytes32 right padded
   console.log(defaultDelegateType);
   const Artifact = await ethers.getContractFactory(artifactName, accounts[0]);
   console.log("Using Base Relay Address:", lacchain.baseRelayAddress);

--- a/test/verificationRegistry/VerificationRegistry.test.ts
+++ b/test/verificationRegistry/VerificationRegistry.test.ts
@@ -4,7 +4,6 @@ import { ethers, lacchain, network } from "hardhat";
 import { keccak256, toUtf8Bytes, formatBytes32String } from "ethers/lib/utils";
 import {
   DIDRegistryGM,
-  verificationRegistry,
   VerificationRegistry,
   VerificationRegistry__factory,
   VerificationRegistryGM,
@@ -115,7 +114,7 @@ describe(artifactName, function () {
     await deployVerificationRegistry();
   });
 
-  describe("Verification Registry", () => {
+  describe("General validation", () => {
     it("Should set right values on contract deployment", async function () {
       const Artifact = await ethers.getContractFactory(artifactName, entity1);
       const ci = Artifact.attach(verificationRegistryAddress);
@@ -137,17 +136,6 @@ describe(artifactName, function () {
       const action = verificationRegistry.issue(digest, exp, entity1.address);
       await handleRevert("IET", action);
     });
-    it("Should throw on issuing an already issued digest by the same entity", async () => {
-      const message = "some message digest";
-      const digest = keccak256(toUtf8Bytes(message));
-      const delta = 3600 * 24 * 365;
-      const exp = Math.floor(Date.now() / 1000) + delta;
-      const Artifact = await ethers.getContractFactory(artifactName, entity1);
-      const verificationRegistry = Artifact.attach(verificationRegistryAddress);
-      await issue(verificationRegistryAddress, message, delta, entity1);
-      const action = verificationRegistry.issue(digest, exp, entity1.address);
-      await handleRevert("RAE", action);
-    });
     it("Shoud throw on attempting to send a transaction with an unauthorized controller", async () => {
       const message = "some message digest";
       const digest = keccak256(toUtf8Bytes(message));
@@ -162,12 +150,20 @@ describe(artifactName, function () {
       );
       await handleRevert("IC", action);
     });
-    it("Should return expected values on revoking a previously issued digest", async () => {
-      const message = "some message";
-      const delta = 3600 * 24 * 365;
-      await issue(verificationRegistryAddress, "some message", delta, entity1);
-      await revoke(verificationRegistryAddress, message, entity1);
-    });
+  });
+
+  describe("Did registry customization methods", () => {
+    it("Shoud fail to add a DIDRegistry by signed way when unauthorized", async () => {});
+    it("Shoud add a DIDRegistry by signed way", async () => {});
+    it("Shoud fail to remove a DIDRegistry by signed way when unauthorized", async () => {});
+    it("Shoud remove a DIDRegistry by signed way", async () => {});
+    it("Shoud fail to add a deletegate type by signed way when unauthorized", async () => {});
+    it("Shoud add a delegate type by signed way", async () => {});
+    it("Shoud fail to remove a delegate type by signed way when unauthorized", async () => {});
+    it("Shoud remove a delegate type by signed way", async () => {});
+  });
+
+  describe("On Hold methods", () => {
     it("Should set onHold to true on setting a digest in onHold", async () => {
       await issue();
       await toggletOnHold(true);
@@ -179,6 +175,15 @@ describe(artifactName, function () {
       await toggletOnHold(true);
       await toggletOnHold(false);
     });
+    it("Shoud fail to toggle onHold status by signed way when unauthorized", async () => {});
+    it("Shoud toggle on Hold by signed way", async () => {});
+    it("Shoud fail to toggle onHold status by signed way by delegate when unauthorized", async () => {});
+    it("Shoud toggle on Hold by delegate by signed way", async () => {});
+    it("Shoud fail to toggle onHold status by signed way by delegate with custom type when unauthorized", async () => {});
+    it("Shoud toggle on Hold by delegate by signed way with custom type", async () => {});
+  });
+
+  describe("Issuance methods", () => {
     it("Should issue by delegate", async () => {
       const organization = entity1;
       const delegate = entity2;
@@ -273,6 +278,78 @@ describe(artifactName, function () {
 
       await handleRevert("DTNS", action);
     });
+
+    it("Should throw on issuing an already issued digest by the same entity", async () => {
+      const message = "some message digest";
+      const digest = keccak256(toUtf8Bytes(message));
+      const delta = 3600 * 24 * 365;
+      const exp = Math.floor(Date.now() / 1000) + delta;
+      const Artifact = await ethers.getContractFactory(artifactName, entity1);
+      const verificationRegistry = Artifact.attach(verificationRegistryAddress);
+      await issue(verificationRegistryAddress, message, delta, entity1);
+      const action = verificationRegistry.issue(digest, exp, entity1.address);
+      await handleRevert("RAE", action);
+    });
+    it("Should issue by signed way", async () => {
+      const organization = ethers.Wallet.createRandom();
+      await issueSigned(organization);
+    });
+    it("Should throw on attempting to issue signed with an invalid signature", async () => {
+      const organization = ethers.Wallet.createRandom();
+      const { typeDataHash, digest, exp } = await getTypedDataHashForIssue(
+        organization.address
+      );
+      // sign type data hash
+      const impersonator = ethers.Wallet.createRandom();
+      const signingKey = impersonator._signingKey;
+      const { v, r, s } = signingKey().signDigest(typeDataHash);
+      // 3. Send Signed Transaction
+      const anySender = entity3;
+      const Artifact = await ethers.getContractFactory(artifactName, anySender);
+      const contractInstance = Artifact.attach(verificationRegistryAddress);
+      const action = contractInstance.issueSigned(
+        digest,
+        exp,
+        organization.address,
+        v,
+        r,
+        s
+      );
+      await handleRevert("IC", action);
+    });
+    it("Should issue by delegate by signed way", async () => {
+      const organization = entity1;
+      const delegate = ethers.Wallet.createRandom();
+      await authorizeDelegate(delegate.address, organization);
+      await issueByDelegateSigned(organization, delegate);
+    });
+    it("Should issue by delegate with custom type by signed way", async () => {
+      const customDelegateType =
+        "0x0be0ff6adc81f13f4d66a7dbb4cd4b6018141f5d65f53b245681255a1d2667f5";
+      const organization = entity1;
+      const delegate = ethers.Wallet.createRandom();
+      await setCustomDelegateType(organization, customDelegateType);
+      await authorizeDelegate(
+        delegate.address,
+        organization,
+        defaultDidRegistryInstance.address,
+        customDelegateType
+      );
+      await issueByDelegateWithCustomDelegateTypeSigned(
+        customDelegateType,
+        organization.address,
+        delegate
+      );
+    });
+  });
+
+  describe("Revocation methods", () => {
+    it("Should return expected values on revoking a previously issued digest", async () => {
+      const message = "some message";
+      const delta = 3600 * 24 * 365;
+      await issue(verificationRegistryAddress, "some message", delta, entity1);
+      await revoke(verificationRegistryAddress, message, entity1);
+    });
     it("Should revoke by delegate", async () => {
       const organization = entity1;
       const delegate = entity2;
@@ -304,66 +381,15 @@ describe(artifactName, function () {
         delegate
       );
     });
-    it("Should issue by signed way", async () => {
-      const organization = ethers.Wallet.createRandom();
-      await issueSigned(organization);
-    });
-    it("Should throw on attempting to issue signed with an invalid signature", async () => {
-      const organization = ethers.Wallet.createRandom();
-      const { typeDataHash, digest, exp } = await getTypedDataHashForIssue(
-        organization.address
-      );
-      // sign type data hash
-      const impersonator = ethers.Wallet.createRandom();
-      const signingKey = impersonator._signingKey;
-      const { v, r, s } = signingKey().signDigest(typeDataHash);
-      // 3. Send Signed Transaction
-      const anySender = entity3;
-      const Artifact = await ethers.getContractFactory(artifactName, anySender);
-      const contractInstance = Artifact.attach(verificationRegistryAddress);
-      const action = contractInstance.issueSigned(
-        digest,
-        exp,
-        organization.address,
-        v,
-        r,
-        s
-      );
-      await handleRevert("IC", action);
-    });
     it("Should revoke by signed way", async () => {
       const organization = ethers.Wallet.createRandom();
       await revokeSigned(organization);
-    });
-    it("Should issue by delegate by signed way", async () => {
-      const organization = entity1;
-      const delegate = ethers.Wallet.createRandom();
-      await authorizeDelegate(delegate.address, organization);
-      await issueByDelegateSigned(organization, delegate);
     });
     it("Should revoke by delegate by signed way", async () => {
       const organization = entity1;
       const delegate = ethers.Wallet.createRandom();
       await authorizeDelegate(delegate.address, organization);
       await revokeByDelegateSigned(organization, delegate);
-    });
-    it("Should issue by delegate with custom type by signed way", async () => {
-      const customDelegateType =
-        "0x0be0ff6adc81f13f4d66a7dbb4cd4b6018141f5d65f53b245681255a1d2667f5";
-      const organization = entity1;
-      const delegate = ethers.Wallet.createRandom();
-      await setCustomDelegateType(organization, customDelegateType);
-      await authorizeDelegate(
-        delegate.address,
-        organization,
-        defaultDidRegistryInstance.address,
-        customDelegateType
-      );
-      await issueByDelegateWithCustomDelegateTypeSigned(
-        customDelegateType,
-        organization.address,
-        delegate
-      );
     });
     it("Should revoke by delegate with custom type by signed way", async () => {
       const customDelegateType =
@@ -382,27 +408,6 @@ describe(artifactName, function () {
         organization.address,
         delegate
       );
-    });
-    it("Should update", async () => {
-      const organization = entity1;
-      const Artifact = await ethers.getContractFactory(
-        artifactName,
-        organization
-      );
-      const contractInstance = Artifact.attach(verificationRegistryAddress);
-      const message = "some message";
-      const digest = keccak256(toUtf8Bytes(message));
-      await issue(verificationRegistryAddress, message);
-      const delta = 3600 * 24 * 2;
-      const exp = Math.floor(Date.now() / 1000) + delta;
-      const result = await contractInstance.update(
-        digest,
-        exp,
-        organization.address
-      );
-      await expect(result)
-        .to.emit(contractInstance, "NewUpdate")
-        .withArgs(digest, organization.address, exp);
     });
     it("Should revoke by delegate with custom did registry and custom delegate type", async () => {
       const customDidRegistry = await deployDidRegistry();
@@ -426,6 +431,30 @@ describe(artifactName, function () {
         organization.address,
         delegate
       );
+    });
+  });
+
+  describe("Update methods", () => {
+    it("Should update", async () => {
+      const organization = entity1;
+      const Artifact = await ethers.getContractFactory(
+        artifactName,
+        organization
+      );
+      const contractInstance = Artifact.attach(verificationRegistryAddress);
+      const message = "some message";
+      const digest = keccak256(toUtf8Bytes(message));
+      await issue(verificationRegistryAddress, message);
+      const delta = 3600 * 24 * 2;
+      const exp = Math.floor(Date.now() / 1000) + delta;
+      const result = await contractInstance.update(
+        digest,
+        exp,
+        organization.address
+      );
+      await expect(result)
+        .to.emit(contractInstance, "NewUpdate")
+        .withArgs(digest, organization.address, exp);
     });
   });
 });

--- a/test/verificationRegistry/VerificationRegistry.test.ts
+++ b/test/verificationRegistry/VerificationRegistry.test.ts
@@ -31,7 +31,8 @@ let verificationRegistryAddress: string;
 let defaultDidRegistryInstance: DIDRegistryGM;
 const genericMessage = "some message";
 const didRegistryArtifactName = "DIDRegistryGM";
-const defaultDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+const delegateTypeWithoutPadding = "veriKey";
+const defaultDelegateType = formatBytes32String(delegateTypeWithoutPadding); // bytes32 right padded
 const EIP712ContractName = "VerificationRegistry";
 const unexpectedErrorMessage = "Unexpected failed";
 const contractVersion = "010";
@@ -200,7 +201,9 @@ describe(artifactName, function () {
     });
     it("Shoud add a delegate type by signed way", async () => {
       const organization = ethers.Wallet.createRandom();
-      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+      const customDelegateType = formatBytes32String(
+        delegateTypeWithoutPadding
+      ); // bytes32 right padded
       await addDelegateTypeSigned(customDelegateType, organization);
     });
     it("Shoud fail to remove a delegate type by signed way when unauthorized", async () => {
@@ -209,7 +212,9 @@ describe(artifactName, function () {
     });
     it("Shoud remove a delegate type by signed way", async () => {
       const organization = ethers.Wallet.createRandom();
-      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+      const customDelegateType = formatBytes32String(
+        delegateTypeWithoutPadding
+      ); // bytes32 right padded
       await addDelegateTypeSigned(customDelegateType, organization);
       await removeDelegateTypeSigned(customDelegateType, organization);
     });
@@ -358,7 +363,9 @@ describe(artifactName, function () {
     it("Shoud toggle on Hold by delegate by signed way with custom type", async () => {
       const message = "someMessage";
       const organization = entity1;
-      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+      const customDelegateType = formatBytes32String(
+        delegateTypeWithoutPadding
+      ); // bytes32 right padded
 
       const delegate = ethers.Wallet.createRandom();
       await authorizeDelegate(delegate.address, organization); // authorize delegate in DID registry
@@ -378,7 +385,9 @@ describe(artifactName, function () {
     it("Shoud failt to toggle on Hold by delegate by signed way with custom type when nonce already used", async () => {
       const message = "someMessage";
       const organization = entity1;
-      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+      const customDelegateType = formatBytes32String(
+        delegateTypeWithoutPadding
+      ); // bytes32 right padded
 
       const delegate = ethers.Wallet.createRandom();
       await authorizeDelegate(delegate.address, organization); // authorize delegate in DID registry

--- a/test/verificationRegistry/VerificationRegistry.test.ts
+++ b/test/verificationRegistry/VerificationRegistry.test.ts
@@ -1,9 +1,10 @@
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
-import { expect } from "chai";
+import { expect, should } from "chai";
 import { ethers, lacchain, network } from "hardhat";
 import { keccak256, toUtf8Bytes, formatBytes32String } from "ethers/lib/utils";
 import {
   DIDRegistryGM,
+  verificationRegistry,
   VerificationRegistry,
   VerificationRegistry__factory,
   VerificationRegistryGM,
@@ -17,6 +18,8 @@ import { DIDRegistry__factory } from "../../typechain-types/factories/utils/iden
 import { DIDRegistryGM__factory } from "../../typechain-types/factories/utils/identity/didRegistryGasModel/DIDRegistry.sol";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { GasModelSignerModified } from "../../GasModelModified";
+import { randomUUID } from "crypto";
+import { identity } from "../../typechain-types/external";
 
 const artifactName = "VerificationRegistryGM";
 let deployer: SignerWithAddress | GasModelSignerModified;
@@ -31,7 +34,7 @@ const didRegistryArtifactName = "DIDRegistryGM";
 const defaultDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
 const EIP712ContractName = "VerificationRegistry";
 const unexpectedErrorMessage = "Unexpected failed";
-const contractVersion = "009";
+const contractVersion = "010";
 describe(artifactName, function () {
   async function deployDidRegistry() {
     let Artifact: DIDRegistry__factory | DIDRegistryGM__factory;
@@ -153,14 +156,63 @@ describe(artifactName, function () {
   });
 
   describe("Did registry customization methods", () => {
-    it("Shoud fail to add a DIDRegistry by signed way when unauthorized", async () => {});
-    it("Shoud add a DIDRegistry by signed way", async () => {});
-    it("Shoud fail to remove a DIDRegistry by signed way when unauthorized", async () => {});
-    it("Shoud remove a DIDRegistry by signed way", async () => {});
-    it("Shoud fail to add a deletegate type by signed way when unauthorized", async () => {});
-    it("Shoud add a delegate type by signed way", async () => {});
-    it("Shoud fail to remove a delegate type by signed way when unauthorized", async () => {});
-    it("Shoud remove a delegate type by signed way", async () => {});
+    it("Shoud add a DIDRegistry by signed way", async () => {
+      const { didRegistry } = await deployDidRegistry();
+      const organization = ethers.Wallet.createRandom();
+
+      await addDidRegistrySigned(didRegistry.address, organization);
+    });
+    it("Should fail when trying to send an already signed transaction", async () => {
+      const { didRegistry } = await deployDidRegistry();
+      const organization = ethers.Wallet.createRandom();
+
+      const { v, r, s, nonce } = await addDidRegistrySigned(
+        didRegistry.address,
+        organization
+      );
+
+      // re send
+      const attacker = entity2;
+      const Artifact = await ethers.getContractFactory(artifactName, attacker);
+      const contractInstance = Artifact.attach(verificationRegistryAddress);
+      const action = contractInstance.addDidRegistrySigned(
+        didRegistry.address,
+        nonce,
+        v,
+        r,
+        s
+      );
+      await handleRevert("NAR", action);
+    });
+    it("Shoud fail to remove a DIDRegistry by signed way when unauthorized", async () => {
+      // when removing an attacker will never be able to remove a registry that was registered by another entity,
+      // since there are no methods that could give a chance for this threat
+    });
+    it("Shoud remove a DIDRegistry by signed way", async () => {
+      const { didRegistry } = await deployDidRegistry();
+      const organization = ethers.Wallet.createRandom();
+      await addDidRegistrySigned(didRegistry.address, organization);
+      await removeDidRegistrySigned(didRegistry.address, organization);
+    });
+    it("Shoud fail to add a deletegate type by signed way when unauthorized", async () => {
+      // when removing an attacker will never be able to add a delegate that was registered by another entity,
+      // since there are no methods that could give a chance for this threat
+    });
+    it("Shoud add a delegate type by signed way", async () => {
+      const organization = ethers.Wallet.createRandom();
+      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+      await addDelegateTypeSigned(customDelegateType, organization);
+    });
+    it("Shoud fail to remove a delegate type by signed way when unauthorized", async () => {
+      // when removing an attacker will never be able to remove a delegate that was registered by another entity,
+      // since there are no methods that could give a chance for this threat
+    });
+    it("Shoud remove a delegate type by signed way", async () => {
+      const organization = ethers.Wallet.createRandom();
+      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+      await addDelegateTypeSigned(customDelegateType, organization);
+      await removeDelegateTypeSigned(customDelegateType, organization);
+    });
   });
 
   describe("On Hold methods", () => {
@@ -175,12 +227,200 @@ describe(artifactName, function () {
       await toggletOnHold(true);
       await toggletOnHold(false);
     });
-    it("Shoud fail to toggle onHold status by signed way when unauthorized", async () => {});
-    it("Shoud toggle on Hold by signed way", async () => {});
+    it("Shoud fail to toggle onHold status by signed way when unauthorized", async () => {
+      const organization = ethers.Wallet.createRandom();
+      const message = "someMessage";
+      const status = true;
+      const digest = keccak256(toUtf8Bytes(message));
+      const nonce = keccak256(toUtf8Bytes(randomUUID()));
+      const { typeDataHash } = await getTypedDataHashForOnHoldType(
+        digest,
+        organization.address,
+        status,
+        nonce
+      );
+      // sign type data hash
+      const attacker = ethers.Wallet.createRandom();
+      const signingKey = attacker._signingKey;
+      const { v, r, s } = signingKey().signDigest(typeDataHash);
+      // 3. Send Signed Transaction
+      const anySender = entity3;
+      const Artifact = await ethers.getContractFactory(artifactName, anySender);
+      const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+      const action = contractInstance.onHoldChangeSigned(
+        digest,
+        organization.address,
+        status,
+        nonce,
+        v,
+        r,
+        s
+      );
+      await handleRevert("IC", action);
+    });
+    it("Shoud toggle on Hold by signed way", async () => {
+      const message = "someMessage";
+      const organization = ethers.Wallet.createRandom();
+      await addOnHoldSigned(message, organization, true);
+    });
     it("Shoud fail to toggle onHold status by signed way by delegate when unauthorized", async () => {});
-    it("Shoud toggle on Hold by delegate by signed way", async () => {});
-    it("Shoud fail to toggle onHold status by signed way by delegate with custom type when unauthorized", async () => {});
-    it("Shoud toggle on Hold by delegate by signed way with custom type", async () => {});
+    it("Shoud toggle on Hold by delegate by signed way", async () => {
+      const message = "someMessage";
+      const organization = entity1;
+      const delegate = ethers.Wallet.createRandom();
+      await authorizeDelegate(delegate.address, organization);
+      const status = true;
+      await addOnHoldByDelegateSigned(
+        message,
+        organization.address,
+        status,
+        delegate
+      );
+    });
+    it("Shoud fail to toggle onHold status by signed way by delegate with custom type when unauthorized", async () => {
+      const message = "someMessage";
+      const organization = entity1;
+      const organizationAddress = organization.address;
+      const randonNonceSeed = randomUUID();
+      const nonce = keccak256(toUtf8Bytes(randonNonceSeed));
+
+      const attacker = ethers.Wallet.createRandom();
+      const status = true;
+      const digest = keccak256(toUtf8Bytes(message));
+      const { typeDataHash } = await getTypedDataHashForOnHoldType(
+        digest,
+        organizationAddress,
+        status,
+        nonce
+      );
+      // sign type data hash
+      const signingKey = attacker._signingKey;
+      const { v, r, s } = signingKey().signDigest(typeDataHash);
+      // 3. Send Signed Transaction
+      const anySender = entity3;
+      const Artifact = await ethers.getContractFactory(artifactName, anySender);
+      const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+      const action = contractInstance.onHoldByDelegateSigned(
+        digest,
+        organizationAddress,
+        status,
+        nonce,
+        v,
+        r,
+        s
+      );
+      await handleRevert("ID", action);
+    });
+    it("Shoud fail to toggle onHold status when sending with the same nonce by the same account", async () => {
+      const message = "someMessage";
+      const organization = entity1;
+      const status = true;
+      const delegate = ethers.Wallet.createRandom();
+      await authorizeDelegate(delegate.address, organization);
+
+      const { nonce } = await addOnHoldByDelegateSigned(
+        message,
+        organization.address,
+        status,
+        delegate
+      );
+
+      const organizationAddress = organization.address;
+
+      const digest = keccak256(toUtf8Bytes(message));
+      const { typeDataHash } = await getTypedDataHashForOnHoldType(
+        digest,
+        organizationAddress,
+        status,
+        nonce
+      );
+      // sign type data hash
+      const signingKey = delegate._signingKey;
+      const { v, r, s } = signingKey().signDigest(typeDataHash);
+      // 3. Send Signed Transaction
+      const anySender = entity3;
+      const Artifact = await ethers.getContractFactory(artifactName, anySender);
+      const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+      const action = contractInstance.onHoldByDelegateSigned(
+        digest,
+        organizationAddress,
+        status,
+        nonce,
+        v,
+        r,
+        s
+      );
+      await handleRevert("IOHCS", action);
+    });
+    it("Shoud toggle on Hold by delegate by signed way with custom type", async () => {
+      const message = "someMessage";
+      const organization = entity1;
+      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+
+      const delegate = ethers.Wallet.createRandom();
+      await authorizeDelegate(delegate.address, organization); // authorize delegate in DID registry
+      await setCustomDelegateType(organization, customDelegateType); // set a delagate type in verification registry
+
+      const status = true;
+
+      await addOnHoldByDelegateWithCustomTypeSigned(
+        customDelegateType,
+        message,
+        organization.address,
+        status,
+        delegate
+      );
+    });
+
+    it("Shoud failt to toggle on Hold by delegate by signed way with custom type when nonce already used", async () => {
+      const message = "someMessage";
+      const organization = entity1;
+      const customDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
+
+      const delegate = ethers.Wallet.createRandom();
+      await authorizeDelegate(delegate.address, organization); // authorize delegate in DID registry
+      await setCustomDelegateType(organization, customDelegateType); // set a delagate type in verification registry
+
+      const status = true;
+
+      const { v, r, s, nonce } = await addOnHoldByDelegateWithCustomTypeSigned(
+        customDelegateType,
+        message,
+        organization.address,
+        status,
+        delegate
+      );
+
+      const organizationAddress = organization.address;
+      const digest = keccak256(toUtf8Bytes(message));
+      const { typeDataHash } =
+        await getTypedDataHashForOnHoldWithCustomTypeOfDelegate_Type(
+          digest,
+          organizationAddress,
+          status,
+          nonce,
+          customDelegateType
+        );
+      // 3. Send Signed Transaction
+      const anySender = entity3;
+      const Artifact = await ethers.getContractFactory(artifactName, anySender);
+      const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+      const action = contractInstance.onHoldByDelegateWithCustomTypeSigned(
+        customDelegateType,
+        organizationAddress,
+        digest,
+        status,
+        nonce,
+        v,
+        r,
+        s
+      );
+      await handleRevert("IOHCS", action);
+    });
   });
 
   describe("Issuance methods", () => {
@@ -967,6 +1207,209 @@ async function getTypedDataHashForRevocation(
   return { typeDataHash, digest };
 }
 
+async function getTypedDataHashForAddDidRegistry(
+  didRegistryAddressCandidate: string,
+  nonce: string,
+  contractName = EIP712ContractName,
+  chainId = network.config.chainId,
+  version = contractVersion
+): Promise<{ typeDataHash: string }> {
+  const ADD_DID_REGISTRY_TYPEHASH = keccak256(
+    toUtf8Bytes("AddDidRegistry(address didRegistryAddress,bytes32 nonce)")
+  );
+
+  // 0. Build digest
+  // const digest = keccak256(toUtf8Bytes(message));
+
+  // 1. Build struct data hash
+  const encodedMessage = defaultAbiCoder.encode(
+    ["bytes32", "address", "bytes32"],
+    [ADD_DID_REGISTRY_TYPEHASH, didRegistryAddressCandidate, nonce]
+  );
+  const structHash = keccak256(arrayify(encodedMessage)); // OK
+
+  // 2. EIP712
+  // 2.1 build domainSeparator
+  const TYPE_HASH = keccak256(
+    toUtf8Bytes(
+      "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    )
+  );
+  const _hashedName = keccak256(toUtf8Bytes(contractName));
+  const _hashedVersion = keccak256(toUtf8Bytes(version));
+
+  const contractAddress = verificationRegistryAddress;
+  const eds = defaultAbiCoder.encode(
+    ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+    [TYPE_HASH, _hashedName, _hashedVersion, chainId, contractAddress]
+  );
+  const domainSeparator = keccak256(eds); // OK
+
+  // 2.2 Build type data hash
+  // Inputs: structHash and domainSeparator
+  const typeData = ethers.utils.solidityPack(
+    ["bytes1", "bytes1", "bytes32", "bytes32"],
+    [0x19, 0x01, domainSeparator, structHash]
+  );
+  const typeDataHash = keccak256(typeData);
+  return { typeDataHash };
+}
+
+async function getTypedDataHashForAddDelegateType(
+  delegateType: string,
+  nonce: string
+): Promise<{ typeDataHash: string }> {
+  const ADD_DELEGATE_TYPEHASH = keccak256(
+    toUtf8Bytes("AddDelegateType(bytes32 delegateType,bytes32 nonce)")
+  );
+
+  // 1. Build struct data hash
+  const encodedMessage = defaultAbiCoder.encode(
+    ["bytes32", "bytes32", "bytes32"],
+    [ADD_DELEGATE_TYPEHASH, delegateType, nonce]
+  );
+
+  const typeDataHash = await getTypedDataHash(encodedMessage);
+  return typeDataHash;
+}
+
+async function getTypedDataHashForOnHoldType(
+  digest: string,
+  identity: string,
+  onHoldStatus: boolean,
+  nonce: string
+): Promise<{ typeDataHash: string }> {
+  const ONHOLD_TYPEHASH = keccak256(
+    toUtf8Bytes(
+      "OnHold(bytes32 digest,address identity,bool onHoldStatus,bytes32 nonce)"
+    )
+  );
+  // 1. Build struct data hash
+  const encodedMessage = defaultAbiCoder.encode(
+    ["bytes32", "bytes32", "address", "bool", "bytes32"],
+    [ONHOLD_TYPEHASH, digest, identity, onHoldStatus, nonce]
+  );
+
+  const typeDataHash = await getTypedDataHash(encodedMessage);
+  return typeDataHash;
+}
+
+async function getTypedDataHashForOnHoldWithCustomTypeOfDelegate_Type(
+  digest: string,
+  identity: string,
+  onHoldStatus: boolean,
+  nonce: string,
+  delegateType: string
+): Promise<{ typeDataHash: string }> {
+  const ONHOLD_WITH_CUSTOM_DELEGATE_TYPE_TYPEHASH = keccak256(
+    toUtf8Bytes(
+      "OnHoldByDelegateWithCustomType(bytes32 digest,address identity,bool onHoldStatus,bytes32 nonce,bytes32 delegateType)"
+    )
+  );
+  // 1. Build struct data hash
+  const encodedMessage = defaultAbiCoder.encode(
+    ["bytes32", "bytes32", "address", "bool", "bytes32", "bytes32"],
+    [
+      ONHOLD_WITH_CUSTOM_DELEGATE_TYPE_TYPEHASH,
+      digest,
+      identity,
+      onHoldStatus,
+      nonce,
+      delegateType,
+    ]
+  );
+
+  const typeDataHash = await getTypedDataHash(encodedMessage);
+  return typeDataHash;
+}
+
+async function getTypedDataHashForRemoveDelegateType(
+  delegateType: string,
+  nonce: string
+): Promise<{ typeDataHash: string }> {
+  const REMOVE_DELEGATE_TYPEHASH = keccak256(
+    toUtf8Bytes("RemoveDelegateType(bytes32 delegateType,bytes32 nonce)")
+  );
+
+  // 1. Build struct data hash
+  const encodedMessage = defaultAbiCoder.encode(
+    ["bytes32", "bytes32", "bytes32"],
+    [REMOVE_DELEGATE_TYPEHASH, delegateType, nonce]
+  );
+
+  const typeDataHash = await getTypedDataHash(encodedMessage);
+  return typeDataHash;
+}
+
+async function getTypedDataHash(
+  encodedMessage: string,
+  contractName = EIP712ContractName,
+  chainId = network.config.chainId,
+  version = contractVersion
+): Promise<{ typeDataHash: string }> {
+  const structHash = keccak256(arrayify(encodedMessage)); // OK
+  const domainSeparator = await getDomainSeparator(
+    contractName,
+    version,
+    chainId
+  );
+  // 2.2 Build type data hash
+  // Inputs: structHash and domainSeparator
+  const typeData = ethers.utils.solidityPack(
+    ["bytes1", "bytes1", "bytes32", "bytes32"],
+    [0x19, 0x01, domainSeparator, structHash]
+  );
+  const typeDataHash = keccak256(typeData);
+  return { typeDataHash };
+}
+
+async function getTypedDataHashForRemoveDidRegistry(
+  nonce: string,
+  contractName = EIP712ContractName,
+  chainId = network.config.chainId,
+  version = contractVersion
+): Promise<{ typeDataHash: string }> {
+  const REMOVE_DID_REGISTRY_TYPEHASH = keccak256(
+    toUtf8Bytes("RemoveDidRegistry(bytes32 nonce)")
+  );
+
+  // 0. Build digest
+  // const digest = keccak256(toUtf8Bytes(message));
+
+  // 1. Build struct data hash
+  const encodedMessage = defaultAbiCoder.encode(
+    ["bytes32", "bytes32"],
+    [REMOVE_DID_REGISTRY_TYPEHASH, nonce]
+  );
+  const structHash = keccak256(arrayify(encodedMessage)); // OK
+
+  // 2. EIP712
+  // 2.1 build domainSeparator
+  const TYPE_HASH = keccak256(
+    toUtf8Bytes(
+      "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    )
+  );
+  const _hashedName = keccak256(toUtf8Bytes(contractName));
+  const _hashedVersion = keccak256(toUtf8Bytes(version));
+
+  const contractAddress = verificationRegistryAddress;
+  const eds = defaultAbiCoder.encode(
+    ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+    [TYPE_HASH, _hashedName, _hashedVersion, chainId, contractAddress]
+  );
+  const domainSeparator = keccak256(eds); // OK
+
+  // 2.2 Build type data hash
+  // Inputs: structHash and domainSeparator
+  const typeData = ethers.utils.solidityPack(
+    ["bytes1", "bytes1", "bytes32", "bytes32"],
+    [0x19, 0x01, domainSeparator, structHash]
+  );
+  const typeDataHash = keccak256(typeData);
+  return { typeDataHash };
+}
+
 async function getDomainSeparator(
   contractName: string,
   version = contractVersion,
@@ -989,4 +1432,254 @@ async function getDomainSeparator(
   );
   const domainSeparator = keccak256(eds);
   return domainSeparator;
+}
+
+async function addDidRegistrySigned(
+  didRegistryAddress: string,
+  organization: Wallet
+) {
+  const randonNonceSeed = randomUUID();
+  const nonce = keccak256(toUtf8Bytes(randonNonceSeed));
+  const { typeDataHash } = await getTypedDataHashForAddDidRegistry(
+    didRegistryAddress,
+    nonce
+  );
+  // sign type data hash
+  const signingKey = organization._signingKey;
+  const { v, r, s } = signingKey().signDigest(typeDataHash);
+  // 3. Send Signed Transaction
+  const anySender = entity3;
+  const Artifact = await ethers.getContractFactory(artifactName, anySender);
+  const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+  const result = await contractInstance.addDidRegistrySigned(
+    didRegistryAddress,
+    nonce,
+    v,
+    r,
+    s
+  );
+  await result.wait();
+  await expect(result)
+    .to.emit(contractInstance, "DidRegistryChange")
+    .withArgs(organization.address, didRegistryAddress, true);
+  return { v, r, s, nonce };
+}
+
+async function removeDidRegistrySigned(
+  didRegistryAddress: string,
+  organization: Wallet
+) {
+  const randonNonceSeed = randomUUID();
+  const nonce = keccak256(toUtf8Bytes(randonNonceSeed));
+  const { typeDataHash } = await getTypedDataHashForRemoveDidRegistry(nonce);
+  // sign type data hash
+  const signingKey = organization._signingKey;
+  const { v, r, s } = signingKey().signDigest(typeDataHash);
+  // 3. Send Signed Transaction
+  const anySender = entity3;
+  const Artifact = await ethers.getContractFactory(artifactName, anySender);
+  const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+  const result = await contractInstance.removeDidRegistrySigned(nonce, v, r, s);
+  await result.wait();
+  await expect(result)
+    .to.emit(contractInstance, "DidRegistryChange")
+    .withArgs(organization.address, didRegistryAddress, false);
+  return { v, r, s, nonce };
+}
+
+async function addDelegateTypeSigned(
+  customDelegateType: string,
+  organization: Wallet
+) {
+  const randonNonceSeed = randomUUID();
+  const nonce = keccak256(toUtf8Bytes(randonNonceSeed));
+  const { typeDataHash } = await getTypedDataHashForAddDelegateType(
+    customDelegateType,
+    nonce
+  );
+  // sign type data hash
+  const signingKey = organization._signingKey;
+  const { v, r, s } = signingKey().signDigest(typeDataHash);
+  // 3. Send Signed Transaction
+  const anySender = entity3;
+  const Artifact = await ethers.getContractFactory(artifactName, anySender);
+  const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+  const result = await contractInstance.addDelegateTypeSigned(
+    customDelegateType,
+    nonce,
+    v,
+    r,
+    s
+  );
+  await result.wait();
+
+  await expect(result)
+    .to.emit(contractInstance, "NewDelegateTypeChange")
+    .withArgs(customDelegateType, organization.address, true);
+  return { v, r, s, nonce };
+}
+
+async function removeDelegateTypeSigned(
+  customDelegateType: string,
+  organization: Wallet
+) {
+  const randonNonceSeed = randomUUID();
+  const nonce = keccak256(toUtf8Bytes(randonNonceSeed));
+  const { typeDataHash } = await getTypedDataHashForRemoveDelegateType(
+    customDelegateType,
+    nonce
+  );
+  // sign type data hash
+  const signingKey = organization._signingKey;
+  const { v, r, s } = signingKey().signDigest(typeDataHash);
+  // 3. Send Signed Transaction
+  const anySender = entity3;
+  const Artifact = await ethers.getContractFactory(artifactName, anySender);
+  const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+  const result = await contractInstance.removeDelegateTypeSigned(
+    customDelegateType,
+    nonce,
+    v,
+    r,
+    s
+  );
+  await result.wait();
+
+  await expect(result)
+    .to.emit(contractInstance, "NewDelegateTypeChange")
+    .withArgs(customDelegateType, organization.address, false);
+  return { v, r, s, nonce };
+}
+
+async function addOnHoldSigned(
+  message = genericMessage,
+  organization: Wallet,
+  status: boolean,
+  nonce = keccak256(toUtf8Bytes(randomUUID()))
+) {
+  const digest = keccak256(toUtf8Bytes(message));
+  const { typeDataHash } = await getTypedDataHashForOnHoldType(
+    digest,
+    organization.address,
+    status,
+    nonce
+  );
+  // sign type data hash
+  const signingKey = organization._signingKey;
+  const { v, r, s } = signingKey().signDigest(typeDataHash);
+  // 3. Send Signed Transaction
+  const anySender = entity3;
+  const Artifact = await ethers.getContractFactory(artifactName, anySender);
+  const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+  const result = await contractInstance.onHoldChangeSigned(
+    digest,
+    organization.address,
+    status,
+    nonce,
+    v,
+    r,
+    s
+  );
+  await result.wait();
+
+  await expect(result)
+    .to.emit(contractInstance, "NewOnHoldChange")
+    .withArgs(digest, organization.address, status, anyValue);
+  const q = await contractInstance.getDetails(organization.address, digest);
+  expect(q.onHold).to.equal(status);
+
+  return { v, r, s, nonce };
+}
+
+async function addOnHoldByDelegateSigned(
+  message = genericMessage,
+  organizationAddress: string,
+  status: boolean,
+  delegate: Wallet,
+  nonce = keccak256(toUtf8Bytes(randomUUID()))
+) {
+  const digest = keccak256(toUtf8Bytes(message));
+  const { typeDataHash } = await getTypedDataHashForOnHoldType(
+    digest,
+    organizationAddress,
+    status,
+    nonce
+  );
+  // sign type data hash
+  const signingKey = delegate._signingKey;
+  const { v, r, s } = signingKey().signDigest(typeDataHash);
+  // 3. Send Signed Transaction
+  const anySender = entity3;
+  const Artifact = await ethers.getContractFactory(artifactName, anySender);
+  const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+  const result = await contractInstance.onHoldByDelegateSigned(
+    digest,
+    organizationAddress,
+    status,
+    nonce,
+    v,
+    r,
+    s
+  );
+  await result.wait();
+
+  await expect(result)
+    .to.emit(contractInstance, "NewOnHoldChange")
+    .withArgs(digest, organizationAddress, status, anyValue);
+  const q = await contractInstance.getDetails(organizationAddress, digest);
+  expect(q.onHold).to.equal(status);
+
+  return { v, r, s, nonce };
+}
+
+async function addOnHoldByDelegateWithCustomTypeSigned(
+  customDelegateType: string,
+  message = genericMessage,
+  organizationAddress: string,
+  status: boolean,
+  delegate: Wallet,
+  nonce = keccak256(toUtf8Bytes(randomUUID()))
+) {
+  const digest = keccak256(toUtf8Bytes(message));
+  const { typeDataHash } =
+    await getTypedDataHashForOnHoldWithCustomTypeOfDelegate_Type(
+      digest,
+      organizationAddress,
+      status,
+      nonce,
+      customDelegateType
+    );
+  // sign type data hash
+  const signingKey = delegate._signingKey;
+  const { v, r, s } = signingKey().signDigest(typeDataHash);
+  // 3. Send Signed Transaction
+  const anySender = entity3;
+  const Artifact = await ethers.getContractFactory(artifactName, anySender);
+  const contractInstance = Artifact.attach(verificationRegistryAddress);
+
+  const result = await contractInstance.onHoldByDelegateWithCustomTypeSigned(
+    customDelegateType,
+    organizationAddress,
+    digest,
+    status,
+    nonce,
+    v,
+    r,
+    s
+  );
+  await result.wait();
+
+  await expect(result)
+    .to.emit(contractInstance, "NewOnHoldChange")
+    .withArgs(digest, organizationAddress, status, anyValue);
+  const q = await contractInstance.getDetails(organizationAddress, digest);
+  expect(q.onHold).to.equal(status);
+
+  return { v, r, s, nonce };
 }

--- a/test/verificationRegistry/VerificationRegistryGM.test.ts
+++ b/test/verificationRegistry/VerificationRegistryGM.test.ts
@@ -2,52 +2,116 @@ import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 import { expect } from "chai";
 import { ethers, lacchain, network } from "hardhat";
 import { keccak256, toUtf8Bytes, formatBytes32String } from "ethers/lib/utils";
-import { DIDRegistryGM } from "../../typechain-types";
+import {
+  DIDRegistryGM,
+  verificationRegistry,
+  VerificationRegistry,
+  VerificationRegistry__factory,
+  VerificationRegistryGM,
+  VerificationRegistryGM__factory,
+} from "../../typechain-types";
 import { Wallet } from "ethers";
 import { defaultAbiCoder } from "ethers/lib/utils";
 import { arrayify } from "@ethersproject/bytes";
+import { DIDRegistry } from "../../typechain-types/utils/identity/didRegistry";
+import { DIDRegistry__factory } from "../../typechain-types/factories/utils/identity/didRegistry";
+import { DIDRegistryGM__factory } from "../../typechain-types/factories/utils/identity/didRegistryGasModel/DIDRegistry.sol";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { GasModelSignerModified } from "../../GasModelModified";
 
 const artifactName = "VerificationRegistryGM";
-const [deployer, entity1, entity2, entity3] = lacchain.getSigners();
+let deployer: SignerWithAddress | GasModelSignerModified;
+let entity1: SignerWithAddress | GasModelSignerModified;
+let entity2: SignerWithAddress | GasModelSignerModified;
+let entity3: SignerWithAddress | GasModelSignerModified;
+
 let verificationRegistryAddress: string;
 let defaultDidRegistryInstance: DIDRegistryGM;
 const genericMessage = "some message";
 const didRegistryArtifactName = "DIDRegistryGM";
 const defaultDelegateType = formatBytes32String("sigAuth"); // bytes32 right padded
 const EIP712ContractName = "VerificationRegistry";
+const unexpectedErrorMessage = "Unexpected failed";
 const contractVersion = "009";
 describe(artifactName, function () {
-  async function deployDidRegistry(
-    keyRotationTime = 3600
-  ): Promise<DIDRegistryGM> {
-    const Artifact = await ethers.getContractFactory(
-      didRegistryArtifactName,
-      deployer
-    );
-    const instance = await lacchain.deployContract(
+  async function deployDidRegistry() {
+    let Artifact: DIDRegistry__factory | DIDRegistryGM__factory;
+    let didRegistry: DIDRegistry | DIDRegistryGM;
+    let owner, account1, account2: SignerWithAddress | GasModelSignerModified;
+    const keyRotationTime = 3600;
+    if (network.name !== "lacchain") {
+      [owner, account1, account2] = await ethers.getSigners();
+      Artifact = await ethers.getContractFactory("DIDRegistry", owner);
+      didRegistry = await Artifact.deploy(keyRotationTime);
+    } else {
+      [owner, account1, account2] = lacchain.getSigners();
+      Artifact = await ethers.getContractFactory("DIDRegistryGM", owner);
+      const instance = await lacchain.deployContract(
+        Artifact,
+        keyRotationTime,
+        lacchain.baseRelayAddress
+      );
+      didRegistry = Artifact.attach(instance.address);
+    }
+
+    return {
+      didRegistry,
+      owner,
+      account1,
+      account2,
       Artifact,
-      keyRotationTime,
-      lacchain.baseRelayAddress
-    );
-    return Artifact.attach(instance.address);
+    };
   }
 
   async function deployVerificationRegistry(
     _defaultDelegateType = defaultDelegateType
   ) {
-    defaultDidRegistryInstance = await deployDidRegistry();
-    const Artifact = await ethers.getContractFactory(artifactName, deployer);
-    const instance = await lacchain.deployContract(
-      Artifact,
-      lacchain.baseRelayAddress,
-      defaultDidRegistryInstance.address,
-      _defaultDelegateType
-    );
+    defaultDidRegistryInstance = (await deployDidRegistry()).didRegistry;
 
-    verificationRegistryAddress = instance.address;
+    let Artifact:
+      | VerificationRegistry__factory
+      | VerificationRegistryGM__factory;
+    let verificationRegistry: VerificationRegistry | VerificationRegistryGM;
+    let owner, account1, account2: SignerWithAddress | GasModelSignerModified;
+    const keyRotationTime = 3600;
+    if (network.name !== "lacchain") {
+      [owner, account1, account2] = await ethers.getSigners();
+      Artifact = await ethers.getContractFactory("VerificationRegistry", owner);
+      verificationRegistry = await Artifact.deploy(
+        defaultDidRegistryInstance.address,
+        _defaultDelegateType
+      );
+    } else {
+      [owner, account1, account2] = lacchain.getSigners();
+      Artifact = await ethers.getContractFactory(
+        "VerificationRegistryGM",
+        owner
+      );
+
+      const instance = await lacchain.deployContract(
+        Artifact,
+        lacchain.baseRelayAddress,
+        defaultDidRegistryInstance.address,
+        _defaultDelegateType
+      );
+      verificationRegistry = Artifact.attach(instance.address);
+    }
+
+    verificationRegistryAddress = verificationRegistry.address;
+
+    return verificationRegistry.address;
+  }
+
+  async function initSigners() {
+    if (network.name != "lacchain") {
+      [deployer, entity1, entity2, entity3] = await ethers.getSigners();
+    } else {
+      [deployer, entity1, entity2, entity3] = lacchain.getSigners();
+    }
   }
 
   this.beforeEach(async function () {
+    await initSigners();
     await deployVerificationRegistry();
   });
 
@@ -70,10 +134,8 @@ describe(artifactName, function () {
       const exp = Math.floor(Date.now() / 1000) + delta;
       const Artifact = await ethers.getContractFactory(artifactName, entity1);
       const verificationRegistry = Artifact.attach(verificationRegistryAddress);
-      try {
-        await verificationRegistry.issue(digest, exp, entity1.address);
-        throw new Error("Workaround ..."); // should never reach here since it is expected that issue operation will fail.
-      } catch (error) {}
+      const action = verificationRegistry.issue(digest, exp, entity1.address);
+      await handleRevert("IET", action);
     });
     it("Should throw on issuing an already issued digest by the same entity", async () => {
       const message = "some message digest";
@@ -82,15 +144,9 @@ describe(artifactName, function () {
       const exp = Math.floor(Date.now() / 1000) + delta;
       const Artifact = await ethers.getContractFactory(artifactName, entity1);
       const verificationRegistry = Artifact.attach(verificationRegistryAddress);
-      await verificationRegistry.issue(digest, exp, entity1.address);
-      try {
-        await verificationRegistry.issue(
-          digest,
-          exp,
-          entity1.address // assuming entity2.address is the main entity
-        );
-        throw new Error("Workaround ..."); // should never reach here since it is expected that issue operation will fail.
-      } catch (error) {}
+      await issue(verificationRegistryAddress, message, delta, entity1);
+      const action = verificationRegistry.issue(digest, exp, entity1.address);
+      await handleRevert("RAE", action);
     });
     it("Shoud throw on attempting to send a transaction with an unauthorized controller", async () => {
       const message = "some message digest";
@@ -99,14 +155,12 @@ describe(artifactName, function () {
       const exp = Math.floor(Date.now() / 1000) + delta;
       const Artifact = await ethers.getContractFactory(artifactName, entity1); // entity1 is the address of the sender account
       const verificationRegistry = Artifact.attach(verificationRegistryAddress);
-      try {
-        await verificationRegistry.issue(
-          digest,
-          exp,
-          entity2.address // assuming entity2.address is the main entity
-        );
-        throw new Error("Workaround ..."); // should never reach here since it is expected that issue operation will fail.
-      } catch (error) {}
+      const action = verificationRegistry.issue(
+        digest,
+        exp,
+        entity2.address // assuming entity2.address is the main entity
+      );
+      await handleRevert("IC", action);
     });
     it("Should return expected values on revoking a previously issued digest", async () => {
       const message = "some message";
@@ -138,10 +192,18 @@ describe(artifactName, function () {
       );
     });
     it("Should throw on issuing with an unauthorized delegate", async () => {
-      try {
-        await issueByDelegate(); // will fail since delegate authorization was not set in advance
-        throw new Error("Workaround ..."); // should never reach here since it is expected that issue operation will fail.
-      } catch (error) {}
+      const message = "some message";
+      const delta = 3600 * 24 * 365;
+      const digest = keccak256(toUtf8Bytes(message));
+      const exp = Math.floor(Date.now() / 1000) + delta;
+      const Artifact = await ethers.getContractFactory(artifactName, entity1);
+      const verificationRegistry = Artifact.attach(verificationRegistryAddress);
+      const action = verificationRegistry.issueByDelegate(
+        entity2.address,
+        digest,
+        exp
+      );
+      await handleRevert("ID", action);
     });
     it("Should issue by delegate with custom type", async () => {
       const customDelegateType =
@@ -165,7 +227,8 @@ describe(artifactName, function () {
       );
     });
     it("Should issue by delegate with custom delegate type and custom didRegistry", async () => {
-      const customDidRegistry = await deployDidRegistry(3600);
+      const result = await deployDidRegistry();
+      const customDidRegistry = result.didRegistry;
       const organization = entity1;
       await addCustomDidRegistry(customDidRegistry.address, organization);
       const customDelegateType =
@@ -193,17 +256,22 @@ describe(artifactName, function () {
         "0x0be0ff6adc81f13f4d66a7dbb4cd4b6018141f5d65f53b245681255a1d2667f5";
       const delegate = entity2;
       await authorizeDelegate(delegate.address, organization); // authorizing delegate with the default delegate type
-      try {
-        await issueByDelegateWithCustomType(
-          customDelegateType,
-          verificationRegistryAddress,
-          "some message",
-          3600 * 24 * 365,
-          organization,
-          delegate
-        );
-        throw new Error("Workaround ..."); // should never reach here since it is expected that issue operation will fail.
-      } catch (error) {}
+
+      const message = "some message";
+      const delta = 3600 * 24 * 365;
+      const digest = keccak256(toUtf8Bytes(message));
+      const exp = Math.floor(Date.now() / 1000) + delta;
+
+      const Artifact = await ethers.getContractFactory(artifactName, delegate);
+      const verificationRegistry = Artifact.attach(verificationRegistryAddress);
+      const action = verificationRegistry.issueByDelegateWithCustomType(
+        customDelegateType,
+        organization.address,
+        digest,
+        exp
+      );
+
+      await handleRevert("DTNS", action);
     });
     it("Should revoke by delegate", async () => {
       const organization = entity1;
@@ -237,47 +305,45 @@ describe(artifactName, function () {
       );
     });
     it("Should issue by signed way", async () => {
-      const organization = entity1;
+      const organization = ethers.Wallet.createRandom();
       await issueSigned(organization);
     });
     it("Should throw on attempting to issue signed with an invalid signature", async () => {
-      const organization = entity1;
+      const organization = ethers.Wallet.createRandom();
       const { typeDataHash, digest, exp } = await getTypedDataHashForIssue(
-        organization
+        organization.address
       );
       // sign type data hash
-      const impersonator = entity2;
+      const impersonator = ethers.Wallet.createRandom();
       const signingKey = impersonator._signingKey;
       const { v, r, s } = signingKey().signDigest(typeDataHash);
       // 3. Send Signed Transaction
       const anySender = entity3;
       const Artifact = await ethers.getContractFactory(artifactName, anySender);
       const contractInstance = Artifact.attach(verificationRegistryAddress);
-      try {
-        await contractInstance.issueSigned(
-          digest,
-          exp,
-          organization.address,
-          v,
-          r,
-          s
-        );
-        throw new Error("Workaround ..."); // should never reach here since it is expected that issue operation will fail before
-      } catch (error) {}
+      const action = contractInstance.issueSigned(
+        digest,
+        exp,
+        organization.address,
+        v,
+        r,
+        s
+      );
+      await handleRevert("IC", action);
     });
     it("Should revoke by signed way", async () => {
-      const organization = entity1;
+      const organization = ethers.Wallet.createRandom();
       await revokeSigned(organization);
     });
     it("Should issue by delegate by signed way", async () => {
       const organization = entity1;
-      const delegate = entity2;
+      const delegate = ethers.Wallet.createRandom();
       await authorizeDelegate(delegate.address, organization);
       await issueByDelegateSigned(organization, delegate);
     });
     it("Should revoke by delegate by signed way", async () => {
       const organization = entity1;
-      const delegate = entity2;
+      const delegate = ethers.Wallet.createRandom();
       await authorizeDelegate(delegate.address, organization);
       await revokeByDelegateSigned(organization, delegate);
     });
@@ -285,7 +351,7 @@ describe(artifactName, function () {
       const customDelegateType =
         "0x0be0ff6adc81f13f4d66a7dbb4cd4b6018141f5d65f53b245681255a1d2667f5";
       const organization = entity1;
-      const delegate = entity2;
+      const delegate = ethers.Wallet.createRandom();
       await setCustomDelegateType(organization, customDelegateType);
       await authorizeDelegate(
         delegate.address,
@@ -295,7 +361,7 @@ describe(artifactName, function () {
       );
       await issueByDelegateWithCustomDelegateTypeSigned(
         customDelegateType,
-        organization,
+        organization.address,
         delegate
       );
     });
@@ -303,7 +369,7 @@ describe(artifactName, function () {
       const customDelegateType =
         "0x0be0ff6adc81f13f4d66a7dbb4cd4b6018141f5d65f53b245681255a1d2667f5";
       const organization = entity1;
-      const delegate = entity2;
+      const delegate = ethers.Wallet.createRandom();
       await setCustomDelegateType(organization, customDelegateType);
       await authorizeDelegate(
         delegate.address,
@@ -313,7 +379,7 @@ describe(artifactName, function () {
       );
       await revokeByDelegateWithCustomDelegateTypeSigned(
         customDelegateType,
-        organization,
+        organization.address,
         delegate
       );
     });
@@ -339,27 +405,46 @@ describe(artifactName, function () {
         .withArgs(digest, organization.address, exp);
     });
     it("Should revoke by delegate with custom did registry and custom delegate type", async () => {
-      const customDidRegistry = await deployDidRegistry(3600);
+      const customDidRegistry = await deployDidRegistry();
       const organization = entity1;
-      await addCustomDidRegistry(customDidRegistry.address, organization);
+      await addCustomDidRegistry(
+        customDidRegistry.didRegistry.address,
+        organization
+      );
       const customDelegateType =
         "0x0be0ff6adc81f13f4d66a7dbb4cd4b6018141f5d65f53b245681255a1d2667f5";
-      const delegate = entity2;
+      const delegate = ethers.Wallet.createRandom();
       await setCustomDelegateType(organization, customDelegateType);
       await authorizeDelegate(
         delegate.address,
         organization,
-        customDidRegistry.address,
+        customDidRegistry.didRegistry.address,
         customDelegateType
       );
       await revokeByDelegateWithCustomDelegateTypeSigned(
         customDelegateType,
-        organization,
+        organization.address,
         delegate
       );
     });
   });
 });
+
+async function handleRevert(revertMessage: string, action: any) {
+  if (network.name != "lacchain") {
+    await expect(action).to.be.revertedWith(revertMessage);
+  } else {
+    try {
+      const tx = await action;
+      tx.wait(); // shoud fail here
+      throw new Error(unexpectedErrorMessage); // should never reach here, if so then contract logic is incorrect
+    } catch (error: any) {
+      if (error.message == unexpectedErrorMessage) {
+        throw new Error(unexpectedErrorMessage);
+      }
+    }
+  }
+}
 
 async function issue(
   _verificationRegistryAddress = verificationRegistryAddress,
@@ -471,7 +556,7 @@ async function issueByDelegateWithCustomType(
 
 async function authorizeDelegate(
   delegateAddress: string,
-  organization: Wallet,
+  organization: SignerWithAddress | GasModelSignerModified,
   didRegistryAddress = defaultDidRegistryInstance.address,
   delegateType = defaultDelegateType
 ) {
@@ -496,7 +581,7 @@ async function authorizeDelegate(
 }
 
 async function setCustomDelegateType(
-  organization: Wallet,
+  organization: SignerWithAddress | GasModelSignerModified,
   customDelegateType: string
 ) {
   const Artifact = await ethers.getContractFactory(artifactName, organization);
@@ -509,7 +594,7 @@ async function setCustomDelegateType(
 
 async function addCustomDidRegistry(
   customDidRegistryAddress: string,
-  organization: Wallet,
+  organization: SignerWithAddress | GasModelSignerModified,
   _verificationRegistryAddress = verificationRegistryAddress
 ) {
   const Artifact = await ethers.getContractFactory(artifactName, organization);
@@ -569,7 +654,7 @@ async function issueSigned(
   anySender = entity2
 ) {
   const { typeDataHash, digest, exp } = await getTypedDataHashForIssue(
-    organization,
+    organization.address,
     contractName,
     message,
     delta,
@@ -605,7 +690,7 @@ async function revokeSigned(
   anySender = entity2
 ) {
   const { typeDataHash, digest } = await getTypedDataHashForRevocation(
-    organization,
+    organization.address,
     contractName,
     message
   );
@@ -629,8 +714,8 @@ async function revokeSigned(
 }
 
 async function issueByDelegateSigned(
-  organization: Wallet,
-  delegate = entity3,
+  organization: SignerWithAddress | GasModelSignerModified,
+  delegate: Wallet,
   contractName = EIP712ContractName,
   message = "some message",
   delta = 3600 * 24 * 365,
@@ -638,7 +723,7 @@ async function issueByDelegateSigned(
   anySender = entity2
 ) {
   const { typeDataHash, digest, exp } = await getTypedDataHashForIssue(
-    organization,
+    organization.address,
     contractName,
     message,
     delta,
@@ -668,14 +753,14 @@ async function issueByDelegateSigned(
 }
 
 async function revokeByDelegateSigned(
-  organization: Wallet,
-  delegate = entity2,
+  organization: SignerWithAddress | GasModelSignerModified,
+  delegate: Wallet,
   contractName = EIP712ContractName,
   message = "some message",
   anySender = entity2
 ) {
   const { typeDataHash, digest } = await getTypedDataHashForRevocation(
-    organization,
+    organization.address,
     contractName,
     message
   );
@@ -700,8 +785,8 @@ async function revokeByDelegateSigned(
 
 async function issueByDelegateWithCustomDelegateTypeSigned(
   delegateType: string,
-  organization: Wallet,
-  delegate = entity3,
+  organizationAddress: string,
+  delegate: Wallet,
   contractName = EIP712ContractName,
   message = "some message",
   delta = 3600 * 24 * 365,
@@ -709,7 +794,7 @@ async function issueByDelegateWithCustomDelegateTypeSigned(
   anySender = entity2
 ) {
   const { typeDataHash, digest, exp } = await getTypedDataHashForIssue(
-    organization,
+    organizationAddress,
     contractName,
     message,
     delta,
@@ -727,29 +812,29 @@ async function issueByDelegateWithCustomDelegateTypeSigned(
       delegateType,
       digest,
       exp,
-      organization.address,
+      organizationAddress,
       v,
       r,
       s
     );
   await expect(result)
     .to.emit(contractInstance, "NewIssuance")
-    .withArgs(digest, organization.address, anyValue, exp);
-  const q = await contractInstance.getDetails(organization.address, digest);
+    .withArgs(digest, organizationAddress, anyValue, exp);
+  const q = await contractInstance.getDetails(organizationAddress, digest);
   expect(q.exp).to.equal(exp);
   expect(q.onHold).to.equal(false);
 }
 
 async function revokeByDelegateWithCustomDelegateTypeSigned(
   delegateType: string,
-  organization: Wallet,
-  delegate = entity3,
+  organizationAddress: string,
+  delegate: Wallet,
   contractName = EIP712ContractName,
   message = "some message",
   anySender = entity2
 ) {
   const { typeDataHash, digest } = await getTypedDataHashForRevocation(
-    organization,
+    organizationAddress,
     contractName,
     message
   );
@@ -764,18 +849,18 @@ async function revokeByDelegateWithCustomDelegateTypeSigned(
     await contractInstance.revokeByDelegateWithCustomDelegateTypeSigned(
       delegateType,
       digest,
-      organization.address,
+      organizationAddress,
       v,
       r,
       s
     );
   await expect(result)
     .to.emit(contractInstance, "NewRevocation")
-    .withArgs(digest, organization.address, anyValue, anyValue);
+    .withArgs(digest, organizationAddress, anyValue, anyValue);
 }
 
 async function getTypedDataHashForIssue(
-  organization: Wallet,
+  organizationAddress: String,
   contractName = EIP712ContractName,
   message = "some message",
   delta = 3600 * 24 * 365,
@@ -793,7 +878,7 @@ async function getTypedDataHashForIssue(
   const exp = Math.floor(Date.now() / 1000) + delta;
   const encodedMessage = defaultAbiCoder.encode(
     ["bytes32", "bytes32", "uint256", "address"],
-    [ISSUE_TYPEHASH, digest, exp, organization.address]
+    [ISSUE_TYPEHASH, digest, exp, organizationAddress]
   );
   const structHash = keccak256(arrayify(encodedMessage)); // OK
 
@@ -825,7 +910,7 @@ async function getTypedDataHashForIssue(
 }
 
 async function getTypedDataHashForRevocation(
-  organization: Wallet,
+  organizationAddress: string,
   contractName = EIP712ContractName,
   message = "some message"
 ): Promise<{ typeDataHash: string; digest: string }> {
@@ -838,7 +923,7 @@ async function getTypedDataHashForRevocation(
   // 1. Build struct data hash
   const encodedMessage = defaultAbiCoder.encode(
     ["bytes32", "bytes32", "address"],
-    [ISSUE_TYPEHASH, digest, organization.address]
+    [ISSUE_TYPEHASH, digest, organizationAddress]
   );
   const structHash = keccak256(arrayify(encodedMessage));
 


### PR DESCRIPTION
* Test: Add unit tests support on local generic development EVM 
* Feat: Add methods to add custom DIDRegistry and custom delegate types using meta transactions with EIP-712
* Feat: Add methods to set onHold by default delegate and default delegate with custom type using meta transactions with EIP-712
* Test: Add unit tests for adding delegates, didRegistries, and update onHold status